### PR TITLE
Add sansdb template tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `{% sansdb %}` template tag.
+
 ## [1.0.0] - 2022-06-08
 
 - Add support for configs with multiple databases.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Tools for limiting access to the database in parts of your Django code.
 pip install django-sans-db
 ```
 
+If you wish to use the `{% sansdb %}` template tag,
+you will need to add `"sans_db"` to your `INSTALLED_APPS`.
+
 ## Usage
 
 ### Context manager
@@ -63,3 +66,42 @@ Attempts to query the database will now cause a `sans_db.exceptions.DatabaseAcce
 
 Please refer to Django's docs on [support for template engines](https://docs.djangoproject.com/en/4.0/topics/templates/#support-for-template-engines)
 for details on how to set this up as a secondary template renderer.
+
+
+### Template tag
+
+You can block DB access in a portion of your template
+by wrapping it with the `{% sansdb %}` template tag.
+
+The template tag accepts database aliases as either strings, or variables.
+If passed as a variable, either strings or iterables of strings are accepted.
+If no aliases are passed, all databases will be blocked.
+
+Note: `DatabaseAccessBlocked` is raised when an attempt is made to access the DB.
+
+To block all databases:
+
+```django
+{% load sansdb %}
+{% sansdb %}
+    {# ... #}
+{% endsansdb %}
+```
+
+To block a list of databases named in the template:
+
+```django
+{% load sansdb %}
+{% sansdb "second_db" "third_db" %}
+    {# ... #}
+{% endsansdb %}
+```
+
+To block a list of databases from a context variable:
+
+```django
+{% load sansdb %}
+{% sansdb databases %}
+    {# ... #}
+{% endsansdb %}
+```

--- a/sans_db/templatetags/sansdb.py
+++ b/sans_db/templatetags/sansdb.py
@@ -1,0 +1,69 @@
+from typing import Iterable, List, Union
+
+from django import template
+
+from ..context_managers import block_db
+
+
+register = template.Library()
+
+
+def _flatten(items: Iterable[Union[str, Iterable[str]]]) -> List[str]:
+    flattened: List[str] = []
+    for item in items:
+        if isinstance(item, Iterable) and not isinstance(item, str):
+            flattened.extend(item)
+        else:
+            flattened.append(item)
+
+    return flattened
+
+
+class SansDBNode(template.Node):
+    def __init__(self, nodelist: template.NodeList, args: List[str]) -> None:
+        self.nodelist = nodelist
+        self.args = [template.Variable(arg) for arg in args]
+
+    def render(self, context: template.Context) -> str:
+        db_aliases = _flatten([var.resolve(context) for var in self.args])
+        with block_db(databases=db_aliases or None):
+            output = self.nodelist.render(context)
+        return output
+
+
+@register.tag
+def sansdb(parser: template.base.Parser, token: template.base.Token) -> SansDBNode:
+    """
+    A tag for blocking DB access in a portion of your template.
+
+    Raises DatabaseAccessBlocked when an attempt is made to access the database.
+
+    Accepts database aliases as either strings, or variables.
+    If passed as a variable, either strings or iterables of strings are accepted.
+    If no aliases are passed, all databases will be blocked.
+
+    Eg: To block all databases:
+
+        {% load sansdb %}
+        {% sansdb %}
+            {# ... #}
+        {% endsansdb %}
+
+    Eg: To block databases named in the template:
+
+        {% load sansdb %}
+        {% sansdb "second_db" "third_db" %}
+            {# ... #}
+        {% endsansdb %}
+
+    Eg: To block databases from a context variable:
+
+        {% load sansdb %}
+        {% sansdb databases %}
+            {# ... #}
+        {% endsansdb %}
+    """
+    _, *args = token.split_contents()
+    nodelist = parser.parse(("endsansdb",))
+    parser.delete_first_token()
+    return SansDBNode(nodelist, args)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -13,10 +13,15 @@ DATABASES = {
 SECRET_KEY = "only-for-tests"
 
 INSTALLED_APPS = [
+    "sans_db",
     "tests",
 ]
 
 TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+    },
     {
         "BACKEND": "sans_db.template_backends.django_sans_db.DjangoTemplatesSansDB",
         "APP_DIRS": True,

--- a/tests/test_template_tags.py
+++ b/tests/test_template_tags.py
@@ -1,0 +1,125 @@
+import pytest
+from django.template import engines
+from django.template.exceptions import TemplateSyntaxError
+
+from sans_db.exceptions import DatabaseAccessBlocked
+
+from .definitions import DATABASE_ALIASES
+from .models import ExampleModel
+
+
+DJANGO_ENGINE = engines["django"]
+
+
+@pytest.mark.django_db(databases=DATABASE_ALIASES)
+class TestSansDBTemplateTag:
+    def test_unclosed_tag(self) -> None:
+        """The sansdb tag must be closed."""
+        template_string = """
+            {% load sansdb %}
+            {% sansdb %}
+        """
+
+        with pytest.raises(TemplateSyntaxError):
+            DJANGO_ENGINE.from_string(template_string)
+
+    @pytest.mark.parametrize("database", DATABASE_ALIASES)
+    def test_no_dbs(self, database: str) -> None:
+        """When no DB is passed, all are blocked."""
+        context = {"items": ExampleModel.objects.using(database).all()}
+        template_string = """
+            {% load sansdb %}
+            {% sansdb %}
+                {% for item in items %}{{ item.pk }}{% endfor %}
+            {% endsansdb %}
+        """
+
+        template = DJANGO_ENGINE.from_string(template_string)
+
+        with pytest.raises(DatabaseAccessBlocked):
+            template.render(context)
+
+    @pytest.mark.parametrize("database", DATABASE_ALIASES)
+    def test_all_dbs(self, database: str) -> None:
+        """When explicit DBs are passed, they are blocked."""
+        context = {"items": ExampleModel.objects.using(database).all()}
+        template_string = """
+            {% load sansdb %}
+            {% sansdb "mysql" "postgres" "sqlite" %}
+                {% for item in items %}{{ item.pk }}{% endfor %}
+            {% endsansdb %}
+        """
+
+        template = DJANGO_ENGINE.from_string(template_string)
+
+        with pytest.raises(DatabaseAccessBlocked):
+            template.render(context)
+
+    @pytest.mark.parametrize("database", DATABASE_ALIASES)
+    def test_variable_dbs(self, database: str) -> None:
+        """When explicit DBs are passed as a list, they are blocked."""
+        context = {
+            "items": ExampleModel.objects.using(database).all(),
+            "databases": [database],
+        }
+        template_string = """
+            {% load sansdb %}
+            {% sansdb databases %}
+                {% for item in items %}{{ item.pk }}{% endfor %}
+            {% endsansdb %}
+        """
+
+        template = DJANGO_ENGINE.from_string(template_string)
+
+        with pytest.raises(DatabaseAccessBlocked):
+            template.render(context)
+
+    @pytest.mark.parametrize("database", DATABASE_ALIASES)
+    def test_other_dbs(self, database: str) -> None:
+        """When queries are not in the passed list, they are allowed."""
+        context = {
+            "items": ExampleModel.objects.using(database).all(),
+            "databases": DATABASE_ALIASES - {database},
+        }
+        template_string = """
+            {% load sansdb %}
+            {% sansdb databases %}
+                {% for item in items %}{{ item.pk }}{% endfor %}
+            {% endsansdb %}
+        """
+
+        template = DJANGO_ENGINE.from_string(template_string)
+
+        template.render(context)
+
+    @pytest.mark.parametrize("database", DATABASE_ALIASES)
+    def test_before_tag(self, database: str) -> None:
+        """Queries before the tag are not blocked."""
+        obj = ExampleModel.objects.using(database).create()
+        context = {"items": ExampleModel.objects.using(database).all()}
+        template_string = """
+            {% load sansdb %}
+            {% for item in items %}{{ item.pk }}{% endfor %}
+            {% sansdb %}{% endsansdb %}
+        """
+
+        template = DJANGO_ENGINE.from_string(template_string)
+
+        rendered = template.render(context)
+        assert rendered.strip() == str(obj.pk)
+
+    @pytest.mark.parametrize("database", DATABASE_ALIASES)
+    def test_after_tag(self, database: str) -> None:
+        """Queries after the tag are not blocked."""
+        obj = ExampleModel.objects.using(database).create()
+        context = {"items": ExampleModel.objects.using(database).all()}
+        template_string = """
+            {% load sansdb %}
+            {% sansdb %}{% endsansdb %}
+            {% for item in items %}{{ item.pk }}{% endfor %}
+        """
+
+        template = DJANGO_ENGINE.from_string(template_string)
+
+        rendered = template.render(context)
+        assert rendered.strip() == str(obj.pk)


### PR DESCRIPTION
This introduces a way to limit DB access in a subsection of your template render by using a template tag.