### PR TITLE
Use `block_db` as a decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Remove upper limit on Python version.
   This should prevent issues when installing for new versions of Python.
 - Add Django 4.1 to text matrix.
+- Add tests for using `block_db` as a decorator.
+  This was working before, but not officially supported.
 
 ## [1.1.0] - 2022-06-11
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ with block_db(databases=["replica"]):
     User.objects.using("replica").get()  # Raises DatabaseAccessBlocked
 ```
 
+
+### Decorator
+
+You can decorate functions and methods with `block_db` to block database access in them. Eg:
+
+```python
+from sans_db.context_managers import block_db
+
+class MyClass:
+    def allowed(self):
+        User.objects.create(...)  # Works outside of block_db()
+
+    @block_db()
+    def not_allowed(self):
+        User.objects.create(...)  # Raises DatabaseAccessBlocked
+```
+
+
 ### Template backend
 
 You can block access to the database when rendering Django templates with our custom template backend.

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -22,8 +22,7 @@ class TestBlockDB:
     def test_evaluated_queryset_allowed(self, database: str) -> None:
         queryset = list(ExampleModel.objects.using(database).all())
         with block_db():
-            for model in queryset:
-                pass
+            list(queryset)
 
     @pytest.mark.parametrize("blocked", DATABASE_ALIASES)
     def test_selective_blocking_blocked(self, blocked: str) -> None:

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -9,6 +9,8 @@ from .models import ExampleModel
 
 @pytest.mark.django_db(databases=DATABASE_ALIASES)
 class TestBlockDB:
+    """Tests for block_db when used as a context manager."""
+
     @pytest.mark.parametrize("database", DATABASE_ALIASES)
     def test_queryset_evaluation_blocked(self, database: str) -> None:
         queryset = ExampleModel.objects.using(database).all()

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,0 +1,54 @@
+import pytest
+
+from sans_db.context_managers import block_db
+from sans_db.exceptions import DatabaseAccessBlocked
+
+from .definitions import DATABASE_ALIASES
+from .models import ExampleModel
+
+
+@pytest.mark.django_db(databases=DATABASE_ALIASES)
+class TestBlockDBFunctionDecorator:
+    """Tests for block_db when used as a function decorator."""
+
+    @pytest.mark.parametrize("database", DATABASE_ALIASES)
+    def test_queryset_evaluation_blocked(self, database: str) -> None:
+        queryset = ExampleModel.objects.using(database).all()
+
+        @block_db()
+        def func() -> None:
+            list(queryset)
+
+        with pytest.raises(DatabaseAccessBlocked):
+            func()
+
+    @pytest.mark.parametrize("database", DATABASE_ALIASES)
+    def test_evaluated_queryset_allowed(self, database: str) -> None:
+        queryset = list(ExampleModel.objects.using(database).all())
+
+        @block_db()
+        def func() -> None:
+            list(queryset)
+
+        # No error raised, because query isn't on blocked DB.
+        func()
+
+    @pytest.mark.parametrize("blocked", DATABASE_ALIASES)
+    def test_selective_blocking_blocked(self, blocked: str) -> None:
+        @block_db(databases=[blocked])
+        def func() -> None:
+            ExampleModel.objects.using(blocked).create()
+
+        with pytest.raises(DatabaseAccessBlocked):
+            func()
+
+    @pytest.mark.parametrize("blocked", DATABASE_ALIASES)
+    def test_selective_blocking_allowed(self, blocked: str) -> None:
+        @block_db(databases=[blocked])
+        def func(db: str) -> None:
+            ExampleModel.objects.using(db).create()
+
+        # No error raised, because queries aren't on blocked DB.
+        not_blocked = DATABASE_ALIASES - {blocked}
+        for db in not_blocked:
+            func(db)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -52,3 +52,54 @@ class TestBlockDBFunctionDecorator:
         not_blocked = DATABASE_ALIASES - {blocked}
         for db in not_blocked:
             func(db)
+
+
+@pytest.mark.django_db(databases=DATABASE_ALIASES)
+class TestBlockDBMethodDecorator:
+    """Tests for block_db when used as a method decorator."""
+
+    @pytest.mark.parametrize("database", DATABASE_ALIASES)
+    def test_queryset_evaluation_blocked(self, database: str) -> None:
+        queryset = ExampleModel.objects.using(database).all()
+
+        class MyClass:
+            @block_db()
+            def run(self) -> None:
+                list(queryset)
+
+        with pytest.raises(DatabaseAccessBlocked):
+            MyClass().run()
+
+    @pytest.mark.parametrize("database", DATABASE_ALIASES)
+    def test_evaluated_queryset_allowed(self, database: str) -> None:
+        queryset = list(ExampleModel.objects.using(database).all())
+
+        class MyClass:
+            @block_db()
+            def run(self) -> None:
+                list(queryset)
+
+        # No error raised, because query isn't on blocked DB.
+        MyClass().run()
+
+    @pytest.mark.parametrize("blocked", DATABASE_ALIASES)
+    def test_selective_blocking_blocked(self, blocked: str) -> None:
+        class MyClass:
+            @block_db(databases=[blocked])
+            def run(self) -> None:
+                ExampleModel.objects.using(blocked).create()
+
+        with pytest.raises(DatabaseAccessBlocked):
+            MyClass().run()
+
+    @pytest.mark.parametrize("blocked", DATABASE_ALIASES)
+    def test_selective_blocking_allowed(self, blocked: str) -> None:
+        class MyClass:
+            @block_db(databases=[blocked])
+            def run(self, db: str) -> None:
+                ExampleModel.objects.using(db).create()
+
+        # No error raised, because queries aren't on blocked DB.
+        not_blocked = DATABASE_ALIASES - {blocked}
+        for db in not_blocked:
+            MyClass().run(db)


### PR DESCRIPTION
It turns out we accidentally supported using `block_db` as a decorator. This makes support official.

Fixes #21 