### PR TITLE
Upgrade to the latest version of isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 


### PR DESCRIPTION
`pre-commit` fails to install isort 5.11.4 with error "RuntimeError: The Poetry configuration is invalid". 

See:
https://stackoverflow.com/questions/75281731/pre-commit-fails-to-install-isort-5-10-1-with-error-runtimeerror-the-poetry-co 
https://github.com/pre-commit/pre-commit/issues/2730